### PR TITLE
Enable build and sign of packages for Oracle Linux 9

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,8 +2,6 @@
 name: Lint code base
 
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     branches: [main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-oraclelinux7/gpg/*.asc
-oraclelinux7/gpg/passphrase
-oraclelinux8/gpg/*.asc
-oraclelinux8/gpg/passphrase
+# Ignore the GPG key and passphrase files
+*.asc
+passphrase
+# Ignore all the output RPMs
 **/output/*.rpm

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Building `subscription-manager` RPMs on Oracle Linux
 
-This repo contains the `Dockerfile` and `build-rshm.sh` files to automatically
-build the appropriate `subscription-manager` RPMs for Oracle Linux 7 and 8.
+This repository contains the `Dockerfile` and `build-rshm.sh` files to automatically
+build the appropriate `subscription-manager` RPMs for Oracle Linux 7, 8 and 9.
 
 ## Requirements
 
@@ -9,8 +9,9 @@ A host machine that has a relatively recent version of Docker installed. I've
 tested this on Oracle Linux, macOS and Windows (using Docker Desktop).
 
 If you want to use GPG to sign the binary RPMs, export your public and private
-keys and concatenate them into `./gpg/key.asc` under _both_ `./oraclelinux7` and
-`./oraclelinux8`. You will also need to place your key passphrase in `./gpg/passphrase`.
+keys and concatenate them into `./gpg/key.asc` under _each of_ `./oraclelinux7`,
+`./oraclelinux8` and `./oraclelinux9`. You will also need to place your key
+passphrase in `./gpg/passphrase`.
 
 > **NOTE:** remember to delete these files afterwards!
 
@@ -24,7 +25,7 @@ If `GPG_NAME_EMAIL` doesn't match your key, the packages will not be signed.
 export GPG_NAME_EMAIL="Jane Builder <jane@builder.com>
 ```
 
-Then, build for each version required:
+### Oracle Linux 7
 
 ```shell
 cd oraclelinux7
@@ -36,14 +37,23 @@ cd oraclelinux7
 > is named `subscription-manager-el7` and it obsoletes all the packages that
 > provide Spacewalk and ULN support.
 
+### Oracle Linux 8
+
 ```shell
 cd oraclelinux8
 ./build-rhsm-ol8.sh
 ```
 
+### Oracle Linux 9
+
+```shell
+cd oraclelinux9
+./build-rhsm-ol9.sh
+```
+
 ## License
 
-Copyright (c) 2021 Avi Miller.
+Copyright (c) 2021, 2023 Avi Miller.
 
 Licensed under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>

--- a/oraclelinux9/Dockerfile
+++ b/oraclelinux9/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright (c) 2021, 2023 Avi Miller
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+# hadolint global ignore=DL3041
+FROM oraclelinux:9
+
+RUN echo > /etc/dnf/vars/ociregion \
+    && dnf config-manager --enable ol9_codeready_builder ol9_distro_builder \
+    && dnf -y install oracle-epel-release-el9 python3-pip python3-setuptools \
+    && dnf config-manager  --setopt=tsflags=nodocs --save \
+    && dnf -y module enable nodejs:18 \
+    && dnf -y groups install "Development Tools" "RPM Development Tools" \
+    && dnf -y install nodejs npm which \
+    && dnf -y clean all \
+    && npm i -g corepack \
+    && corepack prepare yarn@stable --activate \
+    && python3 -m pip install --no-cache-dir tito==0.6.22 \
+    && rpmdev-setuptree
+
+COPY scripts/build-rhsm.sh /
+RUN chmod +x /build-rhsm.sh
+
+CMD ["/build-rhsm.sh"]

--- a/oraclelinux9/build-rhsm-ol9.sh
+++ b/oraclelinux9/build-rhsm-ol9.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, 2023 Avi Miller
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+# find the latest upstream version of the subscription-manager RPM
+RHSM_NVR=$(docker run --rm -it -v "$PWD/scripts:/scripts" registry.access.redhat.com/ubi9/ubi rpm -q --queryformat="%{VERSION}:%{RELEASE}" subscription-manager)
+RHSM_VERSION=$(echo "$RHSM_NVR" | cut -d: -f1)
+RHSM_REL=$(echo "$RHSM_NVR" | cut -d: -f2)
+RHSM_RELEASE=$(echo "$RHSM_REL" | cut -d. -f1)
+RHSM_DIST=$(echo "$RHSM_REL" | cut -d. -f2)
+
+# build image if necessary
+{
+  docker image inspect build-rhsm:ol9 &>/dev/null
+} || {
+  docker build -t build-rhsm:ol9 .
+}
+
+# build the packages in a container which will delete itself once it's done
+docker run --rm -it \
+    --name build-rhsm-ol9 \
+    -v "$PWD/gpg:/gpg" \
+    -v "$PWD/output:/output" \
+    -e RHSM_VERSION="$RHSM_VERSION" \
+    -e RHSM_RELEASE="$RHSM_RELEASE" \
+    -e RHSM_DIST="$RHSM_DIST" \
+    -e GPG_NAME_EMAIL \
+    build-rhsm:ol9

--- a/oraclelinux9/scripts/build-rhsm.sh
+++ b/oraclelinux9/scripts/build-rhsm.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, 2023 Avi Miller
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+# Clone the repo
+cd /root || exit
+git clone https://github.com/candlepin/subscription-manager.git
+
+# Use tito to build the source RPM
+cd /root/subscription-manager || exit
+tito build --tag="subscription-manager-$RHSM_VERSION-$RHSM_RELEASE" --srpm --dist=".$RHSM_DIST" --offline
+cp "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm" /root/rpmbuild/SRPMS/
+
+# use dnf builddep to install the dependencies for the build
+dnf builddep -y "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
+# use rpmbuild --rebuild to build the binary RPM from the src.rpm created by tito
+rpmbuild --rebuild "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
+
+
+# Import the provided GPG signature and sign the binary RPMs using rpmsign
+if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
+
+  # Import and trust the GPG key
+  gpg --import --pinentry-mode loopback --passphrase-file /gpg/passphrase < /gpg/key.asc
+  (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
+
+  cd /root/rpmbuild || exit
+  cat << EOF >> /root/.rpmmacros
+
+%_gpg_sign_cmd_extra_args  --batch --pinentry-mode loopback --passphrase-file /gpg/passphrase
+%_gpg_name ${GPG_NAME_EMAIL}
+EOF
+
+  echo "Signing binary RPMs"
+  find /root/rpmbuild/RPMS -name "*.rpm*" -exec rpmsign --addsign --key-id="$GPG_NAME_EMAIL" {} \;
+
+else
+  echo "Not signing the packages. One or more of the key.asc and passphrase files and the GPG_NAME_EMAIL environment variable are missing."
+fi
+
+
+# Copy the RPMs to the output location
+mkdir /output/oraclelinux9
+cp -r /root/rpmbuild/RPMS/* /output/oraclelinux9/


### PR DESCRIPTION
Installs `tito` via `pip` because Oracle EPEL doesn't have it yet and upstream haven't released all the required dependencies.