### PR TITLE
fix: check out tag before starting package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore the GPG key and passphrase files
 *.asc
 passphrase
-# Ignore all the output RPMs
-**/output/*.rpm
+# Ignore almost everything in the output/ directories
+**/output/*
+!**/output/.gitkeep

--- a/oraclelinux8/build-rhsm-ol8.sh
+++ b/oraclelinux8/build-rhsm-ol8.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
 #
-# Copyright (c) 2021 Avi Miller
+# Copyright (c) 2021, 2023 Avi Miller
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 # find the latest upstream version of the subscription-manager RPM
-RHSM_NVR=$(docker run --rm -it -v $PWD/scripts:/scripts registry.access.redhat.com/ubi8/ubi rpm -q --queryformat="%{VERSION}:%{RELEASE}" subscription-manager)
+RHSM_NVR=$(docker run --rm -it -v "$PWD/scripts:/scripts" registry.access.redhat.com/ubi8/ubi rpm -q --queryformat="%{VERSION}:%{RELEASE}" subscription-manager)
 RHSM_VERSION=$(echo "$RHSM_NVR" | cut -d: -f1)
 RHSM_REL=$(echo "$RHSM_NVR" | cut -d: -f2)
 RHSM_RELEASE=$(echo "$RHSM_REL" | cut -d. -f1)
 RHSM_DIST=$(echo "$RHSM_REL" | cut -d. -f2)
+IMG_VER=$(git rev-parse --short=12 HEAD)
 
 # build image if necessary
 {
-  docker image inspect build-rhsm:ol8 &>/dev/null
+  docker image inspect "build-rhsm:ol8-$IMG_VER" &>/dev/null
 } || {
-  docker build -t build-rhsm:ol8 .
+  docker build -t "build-rhsm:ol8-$IMG_VER" .
 }
 
 # build the packages in a container which will delete itself once it's done
 docker run --rm -it \
-    --name build-rhsm8 \
-    -v $PWD/gpg:/gpg \
-    -v $PWD/output:/output \
-    -e RHSM_VERSION=$RHSM_VERSION \
-    -e RHSM_RELEASE=$RHSM_RELEASE \
-    -e RHSM_DIST=$RHSM_DIST \
+    --name build-rhsm-ol8 \
+    -v "$PWD/gpg:/gpg" \
+    -v "$PWD/output:/output" \
+    -e RHSM_VERSION="$RHSM_VERSION" \
+    -e RHSM_RELEASE="$RHSM_RELEASE" \
+    -e RHSM_DIST="$RHSM_DIST" \
     -e GPG_NAME_EMAIL \
-    build-rhsm:ol8
+    "build-rhsm:ol8-$IMG_VER"

--- a/oraclelinux8/scripts/build-rhsm.sh
+++ b/oraclelinux8/scripts/build-rhsm.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 #
-# Copyright (c) 2021 Avi Miller
+# Copyright (c) 2021, 2023 Avi Miller
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-
 
 # Clone the repo
 cd /root || exit
 git clone https://github.com/candlepin/subscription-manager.git
 
-# Use tito to build the source RPM
+# Checkout the release tag
 cd /root/subscription-manager || exit
+git checkout "subscription-manager-$RHSM_VERSION-$RHSM_RELEASE"
+
+# Use tito to build the source RPM
 tito build --tag="subscription-manager-$RHSM_VERSION-$RHSM_RELEASE" --srpm --dist=".$RHSM_DIST" --offline
 cp "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm" /root/rpmbuild/SRPMS/
 
@@ -33,8 +35,11 @@ else
 fi
 
 dnf builddep -y "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
+# shellcheck disable=SC2086
 rpmbuild --rebuild $SIGN "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
 
 # Copy the RPMs to the output location
-mkdir /output/oraclelinux8
-cp -r /root/rpmbuild/RPMS/* /output/oraclelinux8/
+if [ ! -d /output/oraclelinux8 ]; then
+  mkdir /output/oraclelinux8
+fi
+cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux8/

--- a/oraclelinux9/build-rhsm-ol9.sh
+++ b/oraclelinux9/build-rhsm-ol9.sh
@@ -9,12 +9,13 @@ RHSM_VERSION=$(echo "$RHSM_NVR" | cut -d: -f1)
 RHSM_REL=$(echo "$RHSM_NVR" | cut -d: -f2)
 RHSM_RELEASE=$(echo "$RHSM_REL" | cut -d. -f1)
 RHSM_DIST=$(echo "$RHSM_REL" | cut -d. -f2)
+IMG_VER=$(git rev-parse --short=12 HEAD)
 
 # build image if necessary
 {
-  docker image inspect build-rhsm:ol9 &>/dev/null
+  docker image inspect "build-rhsm:ol9-$IMG_VER" &>/dev/null
 } || {
-  docker build -t build-rhsm:ol9 .
+  docker build -t "build-rhsm:ol9-$IMG_VER" .
 }
 
 # build the packages in a container which will delete itself once it's done
@@ -26,4 +27,4 @@ docker run --rm -it \
     -e RHSM_RELEASE="$RHSM_RELEASE" \
     -e RHSM_DIST="$RHSM_DIST" \
     -e GPG_NAME_EMAIL \
-    build-rhsm:ol9
+    "build-rhsm:ol9-$IMG_VER"

--- a/oraclelinux9/scripts/build-rhsm.sh
+++ b/oraclelinux9/scripts/build-rhsm.sh
@@ -3,29 +3,26 @@
 # Copyright (c) 2021, 2023 Avi Miller
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-
 # Clone the repo
 cd /root || exit
 git clone https://github.com/candlepin/subscription-manager.git
 
-# Use tito to build the source RPM
+# Checkout the release tag
 cd /root/subscription-manager || exit
+git checkout "subscription-manager-$RHSM_VERSION-$RHSM_RELEASE"
+
+# Use tito to build the source RPM
 tito build --tag="subscription-manager-$RHSM_VERSION-$RHSM_RELEASE" --srpm --dist=".$RHSM_DIST" --offline
 cp "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm" /root/rpmbuild/SRPMS/
 
-# use dnf builddep to install the dependencies for the build
-dnf builddep -y "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
-# use rpmbuild --rebuild to build the binary RPM from the src.rpm created by tito
-rpmbuild --rebuild "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
-
-
-# Import the provided GPG signature and sign the binary RPMs using rpmsign
+# Use rpmbuild to build and sign the binary RPMs
 if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
 
   # Import and trust the GPG key
   gpg --import --pinentry-mode loopback --passphrase-file /gpg/passphrase < /gpg/key.asc
   (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
 
+   SIGN="--sign"
   cd /root/rpmbuild || exit
   cat << EOF >> /root/.rpmmacros
 
@@ -33,14 +30,16 @@ if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
 %_gpg_name ${GPG_NAME_EMAIL}
 EOF
 
-  echo "Signing binary RPMs"
-  find /root/rpmbuild/RPMS -name "*.rpm*" -exec rpmsign --addsign --key-id="$GPG_NAME_EMAIL" {} \;
-
 else
   echo "Not signing the packages. One or more of the key.asc and passphrase files and the GPG_NAME_EMAIL environment variable are missing."
 fi
 
+dnf builddep -y "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
+# shellcheck disable=SC2086
+rpmbuild --rebuild $SIGN "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
 
 # Copy the RPMs to the output location
-mkdir /output/oraclelinux9
-cp -r /root/rpmbuild/RPMS/* /output/oraclelinux9/
+if [ ! -d /output/oraclelinux9 ]; then
+  mkdir /output/oraclelinux9
+fi
+cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux9/


### PR DESCRIPTION
Resolves #1 

Also forces the creation of a new build image when this git repo updates, so that the build script inside the image is updated.