### PR TITLE
updated scripts to manage rhsm-certificates on ol8 and ol9

### DIFF
--- a/oraclelinux7/Dockerfile
+++ b/oraclelinux7/Dockerfile
@@ -4,7 +4,7 @@
 FROM oraclelinux:7-slim
 
 RUN yum -y install oracle-epel-release-el7 oracle-nodejs-release-el7 \
-    && yum -y --enablerepo=ol7_optional_latest install @buildsys-build tito rpm-build rpm-sign nodejs which expect \
+    && yum -y --enablerepo=ol7_optional_latest install @buildsys-build tito rpm-build rpm-sign nodejs which expect npm \
     && rm -rf /var/cache/yum \
     && npm install -g yarn \
     && rpmdev-setuptree

--- a/oraclelinux7/scripts/build-rhsm.sh
+++ b/oraclelinux7/scripts/build-rhsm.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 #
-# Copyright (c) 2021 Avi Miller
+# Copyright (c) 2021, 2023 Avi Miller
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-# Import GPG key and trust it
-gpg --import --passphrase-file /gpg/passphrase < /gpg/key.asc
-(echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
-
-# Clone the git repo
+# Clone the repo
 cd /root || exit
 git clone https://github.com/candlepin/subscription-manager.git
 
-# Build the SRPM using tito then install it
-cd subscription-manager || exit
+# Checkout the release tag
+cd /root/subscription-manager || exit
+git checkout "subscription-manager-$RHSM_VERSION-$RHSM_RELEASE"
+
+# Use tito to build the source tar.gz files
+/bin/rpmdev-setuptree
+tito build --tag subscription-manager-$RHSM_VERSION-$RHSM_RELEASE --tgz --offline
+cp "/tmp/tito/subscription-manager-$RHSM_VERSION.tar.gz" /root/rpmbuild/SOURCES/
+cp "/tmp/tito/subscription-manager-cockpit-$RHSM_VERSION.tar.gz" /root/rpmbuild/SOURCES/
+cp -fr /root/subscription-manager/* /root/rpmbuild/SOURCES/
+
+# Use tito to build src.rpm files
 tito build --tag="subscription-manager-$RHSM_VERSION-$RHSM_RELEASE" --srpm --dist=".$RHSM_DIST" --offline
 cp "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm" /root/rpmbuild/SRPMS/
 rpm -ivh "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
@@ -21,17 +27,30 @@ rpm -ivh "/root/rpmbuild/SRPMS/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.
 cd /root/rpmbuild/SPECS || exit
 patch -p0 < /obsolete-rhn-rpms.diff
 
-# Build the binary RPMs
-cd /root/rpmbuild || exit
-yum-builddep -y --enablerepo=ol7_optional_latest "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
-rpmbuild -ba SPECS/subscription-manager.spec
-
-# Sign the binary RPMs if the required files and envvar are provided.
+# Use rpmbuild to build and sign the binary RPMs
 if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
-  echo "%_gpg_name $GPG_NAME_EMAIL" >> /root/.rpmmacros
-  find /root/rpmbuild/RPMS -name '*.rpm' -exec /rpm-sign.exp {} \;
+
+  # Import and trust the GPG key
+  gpg --import --pinentry-mode loopback --passphrase-file /gpg/passphrase < /gpg/key.asc
+  (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
+
+   SIGN="--sign"
+  cd /root/rpmbuild || exit
+  cat << EOF >> /root/.rpmmacros
+
+%_gpg_sign_cmd_extra_args  --batch --pinentry-mode loopback --passphrase-file /gpg/passphrase
+%_gpg_name ${GPG_NAME_EMAIL}
+EOF
+
+else
+  echo "Not signing the packages. One or more of the key.asc and passphrase files and the GPG_NAME_EMAIL environment variable are missing."
 fi
 
+yum-builddep -y --enablerepo=ol7_optional_latest "/tmp/tito/subscription-manager-$RHSM_VERSION-$RHSM_RELEASE.$RHSM_DIST.src.rpm"
+rpmbuild -ba /root/rpmbuild/SPECS/subscription-manager.spec
+
 # Copy the RPMs to the output location
-mkdir /output/oraclelinux7
-cp -r /root/rpmbuild/RPMS/* /output/oraclelinux7/
+if [ ! -d /output/oraclelinux7 ]; then
+  mkdir /output/oraclelinux7
+fi
+cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux7/

--- a/oraclelinux7/scripts/obsolete-rhn-rpms.diff
+++ b/oraclelinux7/scripts/obsolete-rhn-rpms.diff
@@ -5,15 +5,6 @@
  # Prefer systemd over sysv on Fedora and RHEL 7+
  %global use_systemd 0%{?fedora} || (0%{?rhel} && 0%{?rhel} >= 7) || (0%{?suse_version} && 0%{?suse_version} >= 1315)
  # For optional building of ostree-plugin sub package. Unrelated to systemd
-@@ -131,7 +132,7 @@
- 
- %global subpackages SUBPACKAGES="%{?include_syspurpose:syspurpose}"
- 
--Name: subscription-manager
-+Name: subscription-manager-el7
- Version: 1.24.48
- Release: 1%{?dist}
- Summary: Tools and libraries for subscription and repository management
 @@ -144,18 +145,18 @@
  # git clone https://github.com/candlepin/subscription-manager.git
  # yum install tito

--- a/oraclelinux8/scripts/build-rhsm.sh
+++ b/oraclelinux8/scripts/build-rhsm.sh
@@ -43,3 +43,47 @@ if [ ! -d /output/oraclelinux8 ]; then
   mkdir /output/oraclelinux8
 fi
 cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux8/
+
+# Clone the subscription-manager-rhsm-certificates repo
+cd /root || exit
+git clone https://github.com/candlepin/subscription-manager-rhsm-certificates.git
+cd /root/subscription-manager-rhsm-certificates || exit
+
+# Add tag with proper version and release
+git tag subscription-manager-rhsm-certificates-$RHSM_VERSION-$RHSM_RELEASE
+
+# Update Version for subscription-manager-rhsm-certificates
+sed -i "2s/.*/Version: $RHSM_VERSION/" ./subscription-manager-rhsm-certificates.spec
+
+# Use tito to build the tar.gz source file
+tito build --tag subscription-manager-rhsm-certificates-$RHSM_VERSION-$RHSM_RELEASE --tgz --offline
+cp "/tmp/tito/subscription-manager-rhsm-certificates-$RHSM_VERSION.tar.gz" /root/rpmbuild/SOURCES/
+cp -fr /root/subscription-manager-rhsm-certificates/* /root/rpmbuild/SOURCES/
+
+# Use rpmbuild to build and sign the binary RPMs
+if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
+
+# Import and trust the GPG key
+  gpg --import --pinentry-mode loopback --passphrase-file /gpg/passphrase < /gpg/key.asc
+  (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
+
+   SIGN="--sign"
+  cd /root/rpmbuild || exit
+  cat << EOF >> /root/.rpmmacros
+
+%_gpg_sign_cmd_extra_args  --batch --pinentry-mode loopback --passphrase-file /gpg/passphrase
+%_gpg_name ${GPG_NAME_EMAIL}
+EOF
+
+else
+  echo "Not signing the packages. One or more of the key.asc and passphrase files and the GPG_NAME_EMAIL environment variable are missing."
+fi
+
+cd /root/rpmbuild/SOURCES/
+rpmbuild -bb subscription-manager-rhsm-certificates.spec --rebuild $SIGN 
+
+# Copy the RPMs to the output location
+if [ ! -d /output/oraclelinux8 ]; then
+  mkdir /output/oraclelinux8
+fi
+cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux8/

--- a/oraclelinux9/scripts/build-rhsm.sh
+++ b/oraclelinux9/scripts/build-rhsm.sh
@@ -43,3 +43,47 @@ if [ ! -d /output/oraclelinux9 ]; then
   mkdir /output/oraclelinux9
 fi
 cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux9/
+
+# Clone the subscription-manager-rhsm-certificates repo
+cd /root || exit
+git clone https://github.com/candlepin/subscription-manager-rhsm-certificates.git
+cd /root/subscription-manager-rhsm-certificates || exit
+
+# Add tag with proper version and release
+git tag subscription-manager-rhsm-certificates-$RHSM_VERSION-$RHSM_RELEASE
+
+# Update Version for subscription-manager-rhsm-certificates
+sed -i "2s/.*/Version: $RHSM_VERSION/" ./subscription-manager-rhsm-certificates.spec
+
+# Use tito to build the tar.gz source file
+tito build --tag subscription-manager-rhsm-certificates-$RHSM_VERSION-$RHSM_RELEASE --tgz --offline
+cp "/tmp/tito/subscription-manager-rhsm-certificates-$RHSM_VERSION.tar.gz" /root/rpmbuild/SOURCES/
+cp -fr /root/subscription-manager-rhsm-certificates/* /root/rpmbuild/SOURCES/
+
+# Use rpmbuild to build and sign the binary RPMs
+if [ -f /gpg/key.asc ] && [ -f /gpg/passphrase ] && [ "$GPG_NAME_EMAIL" ]; then
+
+# Import and trust the GPG key
+  gpg --import --pinentry-mode loopback --passphrase-file /gpg/passphrase < /gpg/key.asc
+  (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$(gpg --list-packets < /gpg/key.asc | awk '$1=="keyid:"{print$2;exit}')" trust
+
+   SIGN="--sign"
+  cd /root/rpmbuild || exit
+  cat << EOF >> /root/.rpmmacros
+
+%_gpg_sign_cmd_extra_args  --batch --pinentry-mode loopback --passphrase-file /gpg/passphrase
+%_gpg_name ${GPG_NAME_EMAIL}
+EOF
+
+else
+  echo "Not signing the packages. One or more of the key.asc and passphrase files and the GPG_NAME_EMAIL environment variable are missing."
+fi
+
+cd /root/rpmbuild/SOURCES/
+rpmbuild -bb subscription-manager-rhsm-certificates.spec --rebuild $SIGN 
+
+# Copy the RPMs to the output location
+if [ ! -d /output/oraclelinux9 ]; then
+  mkdir /output/oraclelinux9
+fi
+cp -rf /root/rpmbuild/RPMS/* /output/oraclelinux9/


### PR DESCRIPTION
Fixed ol8 and ol9 scripts to get subscription-manager-rhsm-certificates RPM binary built for OL8 and OL9 (wasn't by default).
Verify and updated script and patch to build subscription-manager packages for OL7.